### PR TITLE
feat: search box for city and state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,10 +15,22 @@
         <span>{{ darkTheme ? 'Light theme' : 'Dark theme' }}</span>
       </button>
     </header>
+    <div class="search-section">
+      <label for="geonames-search" class="search-label">Search city and state</label>
+      <input
+        id="geonames-search"
+        v-model="searchQuery"
+        type="search"
+        class="search-input"
+        placeholder="Type city or state name..."
+        autocomplete="off"
+        aria-label="Search city and state"
+      />
+    </div>
     <h3 class="ui header">&lt;GeoNames-State&gt;</h3>
-    <state-table></state-table>
+    <state-table :key="'state-' + searchQuery" :search-query="searchQuery"></state-table>
     <h3 class="ui header">&lt;GeoNames-City&gt;</h3>
-    <city-table></city-table>
+    <city-table :key="'city-' + searchQuery" :search-query="searchQuery"></city-table>
   </div>
 </template>
 
@@ -36,7 +48,8 @@ export default {
   },
   data() {
     return {
-      darkTheme: false
+      darkTheme: false,
+      searchQuery: ''
     };
   },
   mounted() {
@@ -191,5 +204,48 @@ body.theme-dark {
 
 #app.theme-dark .vuetable-pagination .active a {
   color: var(--app-text) !important;
+}
+
+.search-section {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.search-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.search-input {
+  max-width: 320px;
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-size: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input:focus {
+  border-color: #2185d0;
+  box-shadow: 0 0 0 2px rgba(33, 133, 208, 0.2);
+}
+
+#app.theme-dark .search-input {
+  background: var(--app-surface);
+  color: var(--app-text);
+  border-color: var(--app-border);
+}
+
+#app.theme-dark .search-input::placeholder {
+  color: var(--app-text-muted);
+}
+
+#app.theme-dark .search-input:focus {
+  border-color: var(--app-link);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.2);
 }
 </style>

--- a/src/components/CityTable.vue
+++ b/src/components/CityTable.vue
@@ -36,6 +36,9 @@
       VuetablePagination,
       VuetablePaginationInfo
     },
+    props: {
+      searchQuery: { type: String, default: "" }
+    },
     data() {
       return {
         fields: [
@@ -79,13 +82,17 @@
         return this.$http.get(apiUrl, httpOptions);
       },
       makeQueryParams (sortOrder, currentPage, perPage) {
-        return {
+        const params = {
           sort: sortOrder[0].field,
           order: sortOrder[0].direction === 'asc' ? 1 : -1,
           page: currentPage,
           pageSize: perPage,
           _count: 1,
+        };
+        if (this.searchQuery && this.searchQuery.trim()) {
+          params.name = this.searchQuery.trim();
         }
+        return params;
       },
       transformData (data) {
         const transformed = {};

--- a/src/components/StateTable.vue
+++ b/src/components/StateTable.vue
@@ -37,6 +37,9 @@
       VuetablePagination,
       VuetablePaginationInfo
     },
+    props: {
+      searchQuery: { type: String, default: "" }
+    },
     data() {
       return {
         fields: [
@@ -80,13 +83,17 @@
         return this.$http.get(apiUrl, httpOptions)
       },
       makeQueryParams (sortOrder, currentPage, perPage) {
-        return {
+        const params = {
           sort: sortOrder[0].field,
           order: sortOrder[0].direction === 'asc' ? 1 : -1,
           page: currentPage,
           pageSize: perPage,
           _count: 1,
+        };
+        if (this.searchQuery && this.searchQuery.trim()) {
+          params.q = this.searchQuery.trim();
         }
+        return params;
       },
       transformData (data) {
         const transformed = {};


### PR DESCRIPTION
Adds a single search box that filters both tables:

- **Search input** in the app header; filters State table (by name or abbreviation) and City table (by city name).
- **StateTable** and **CityTable** accept `searchQuery` prop and pass it to the API (`q` for state, `name` for city).
- Tables refetch when the search term changes (key-based remount).
- Styling supports light and dark theme.

Made with [Cursor](https://cursor.com)